### PR TITLE
[fix] : 메인페이지에서 캘린더의 날짜를 눌렀을때 GuestList가 하얗게 뜨는 현상 수정

### DIFF
--- a/src/containers/GuestList.tsx
+++ b/src/containers/GuestList.tsx
@@ -46,7 +46,7 @@ export default function GuestList({ customers }: TGuestListProps) {
 
   return (
     <Section title='손님 목록'>
-      <div className='sticky top-0 z-10 w-full bg-white'>
+      <div className='top-0 z-10 w-full bg-white'>
         <SearchField
           placeholder='손님 이름 검색'
           value={searchTerm}


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #126 

## 💻 작업 내용

> ![image](https://github.com/user-attachments/assets/abeffafb-e861-4275-862e-8317780f0393)

> GuestList.tsx의 <div className='sticky top-0 z-10 w-full bg-white'> 에서 sticky 삭제 완료