### PR TITLE
[feat] : 예정된 상담 일정 조회에 관한 api 연결 성공

### DIFF
--- a/src/components/ApprovedConsultationItem.tsx
+++ b/src/components/ApprovedConsultationItem.tsx
@@ -13,13 +13,13 @@ export const ApprovedConsultationItem = ({
   hopeTime,
 }: TConsultingProps) => {
   // 빠른 상담일 경우
-  const getBorderColorClass = (category_id: number) => {
-    return category_id === 1 ? 'quick-border' : 'border-gray-200';
+  const getBorderColorClass = (categoryId: number) => {
+    return categoryId === 1 ? 'quick-border' : 'border-gray-200';
   };
 
   const navigate = useNavigate();
 
-  const handleConsultationClick = (consultingId: number) => {
+  const moveToConsultingPageEvent = (consultingId: number) => {
     navigate(`/consulting/${consultingId}`);
   };
 
@@ -52,7 +52,7 @@ export const ApprovedConsultationItem = ({
         </span>
         <button
           className='border border-hanaindigo rounded-md px-1 text-[0.8rem] text-white bg-hanadeepgreen'
-          onClick={() => handleConsultationClick(id)}
+          onClick={() => moveToConsultingPageEvent(id)}
         >
           상담하기
         </button>

--- a/src/containers/ApprovedConsultationsList.tsx
+++ b/src/containers/ApprovedConsultationsList.tsx
@@ -2,19 +2,14 @@ import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { ApprovedConsultationItem } from '../components/ApprovedConsultationItem';
 import Section from '../components/Section';
+import useFetch from '../hooks/useFetch';
 import { type TConsultingProps } from '../types/dataTypes';
 
-type ScheduledConsultationListProps = {
-  consultations: TConsultingProps[];
-};
-
 // 예정된 상담 일정
-export default function ApprovedConsultationsList({
-  consultations,
-}: ScheduledConsultationListProps) {
-  const [consultationData, setConsultationData] = useState<TConsultingProps[]>(
-    []
-  );
+export default function ApprovedConsultationsList() {
+  const [consultationData, setConsultationData] = useState<
+    TConsultingProps[] | null
+  >([]);
   const { id } = useParams();
 
   // useEffect(() => {
@@ -48,30 +43,30 @@ export default function ApprovedConsultationsList({
   //   fetchNotConsultingData();
   // }, [id, consultations]);
 
-  const allConsultations = [...consultationData, ...consultations].sort(
-    (a, b) => {
-      if (a.title === '삐른 상담 요청' && !(b.title === '삐른 상담 요청'))
-        return -1;
-      if (!(a.title === '삐른 상담 요청') && b.title === '삐른 상담 요청')
-        return 1;
-      return new Date(a.hopeDate).getTime() - new Date(b.hopeDate).getTime();
-    }
+  const { data, error } = useFetch<TConsultingProps[]>(
+    'pb/reserves?status=true&type=upcoming'
   );
+
+  useEffect(() => {
+    setConsultationData(data);
+  }, [data]);
+  console.error(error);
 
   return (
     <Section
-      title={
-        id
-          ? // 추후 수정 필요
-            `${consultationData[0]?.customerName || id} 손님의 예정된 상담 일정`
-          : '예정된 상담 일정'
-      }
+      // title={
+      //   id
+      //     ? // 추후 수정 필요
+      //       `${consultationData[id]} 손님의 예정된 상담 일정`
+      //     : '예정된 상담 일정'
+      // }
+      title='(손님의) 예정된 상담 일정'
       layoutClassName='h-full'
     >
       <div className='w-full p-4 '>
-        {allConsultations.length > 0 ? (
-          allConsultations.map((consultation, index) => (
-            <ApprovedConsultationItem key={index} {...consultation} />
+        {consultationData ? (
+          consultationData.map((consultationData, index) => (
+            <ApprovedConsultationItem key={index} {...consultationData} />
           ))
         ) : (
           <div className='text-center text-hanaindigo text-xl'>


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #148

## 💻 작업 내용

> api 연결 및 데이터 반영 확인

## 💬 메모
mainPage는 문제가 없으나, 
특정 손님에 관한 customerDetail 페이지에 들어갔을 때 해당 손님의 예정된 상담일정 조회는 
customerList 컴포넌트를 GET api 연결한 후 해결할 예정

