### PR TITLE
[feat] : 로그인 api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import NotificationPage from './pages/NotificationPage';
 
 const ProtectedLayout = () => {
   const navigate = useNavigate();
-  const isLogin = localStorage.getItem('user');
+  const isLogin = localStorage.getItem('loginPB');
 
   useEffect(() => {
     if (!isLogin) {

--- a/src/containers/Login.tsx
+++ b/src/containers/Login.tsx
@@ -1,61 +1,48 @@
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
-import PbJsonData from '../../public/data/PB.json';
 import { Button } from '../components/ui/button';
-import { useSession } from '../hooks/sessionContext';
-import { type TPbProps } from '../types/dataTypes';
+import { type TPbDataProps } from '../types/dataTypes';
 
 export default function Login() {
-  const { handleLoginEvent } = useSession();
-  const pbData = PbJsonData;
-
+  const [isValidLoginInfo, setIsValidLoginInfo] = useState(true); // 유효성 상태
   const loginIdRef = useRef<HTMLInputElement | null>(null);
   const passwordRef = useRef<HTMLInputElement | null>(null);
-  let [isValidLoginInfo, setIsValidLoginInfo] = useState(true);
   const navigate = useNavigate();
 
-  const handleLoginSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleLoginSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const loginId = loginIdRef.current?.value;
-    const password = passwordRef.current?.value;
 
-    if (loginId && password) {
-      const loginUser = validCheck(loginId, password);
-      if (loginUser) {
-        handleLoginEvent(loginUser);
+    const loginId = loginIdRef.current?.value || '';
+    const password = passwordRef.current?.value || '';
+
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_KEY}/pb/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ id: loginId, pw: password }),
+      });
+
+      if (!response.ok) {
+        throw new Error('로그인 실패');
+      }
+
+      const data: { message: string; pbData: TPbDataProps } =
+        await response.json();
+
+      if (data.message === 'Login successful') {
+        localStorage.setItem('loginPB', JSON.stringify(data.pbData));
+        alert('오늘 하루도 힘내세요!😊🍀');
         navigate('/');
       } else {
-        setIsValidLoginInfo(false);
-        loginIdRef.current?.focus();
+        throw new Error('로그인 실패');
       }
+    } catch (error) {
+      console.error('로그인 오류:', error);
+      setIsValidLoginInfo(false);
+      loginIdRef.current?.focus();
     }
-  };
-
-  // 로그인 체크 로직
-  const validCheck = (
-    inputLoginId: string,
-    inputPassword: string
-  ): TPbProps | null => {
-    // 정규식 패턴
-    const loginIdPattern = /^Hana\d{9}$/;
-    const passwordPattern =
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[$@$!%*#?&])[A-Za-z\d$@$!%*#?&]{8,20}$/;
-
-    // 정규식 체크
-    if (
-      !loginIdPattern.test(inputLoginId) ||
-      !passwordPattern.test(inputPassword)
-    ) {
-      return null;
-    }
-
-    // 존재 여부
-    const loginUser = pbData.find(
-      ({ login_id, password }) =>
-        login_id === inputLoginId && password === inputPassword
-    );
-
-    return loginUser || null;
   };
 
   useEffect(() => {
@@ -80,7 +67,7 @@ export default function Login() {
               '사원번호를 입력해주세요.'
             )
           }
-          onInput={(e) => (e.target as HTMLInputElement).setCustomValidity('')} // 입력 시 메시지 초기화
+          onInput={(e) => (e.target as HTMLInputElement).setCustomValidity('')}
         />
         <input
           className='border border-t-0 border-gray-300 py-3 pl-3'
@@ -98,10 +85,12 @@ export default function Login() {
         />
       </div>
       <div
-        className={`text-red-400 p-1 text-sm ${isValidLoginInfo ? 'invisible' : 'visible '}`}
+        className={`text-red-400 p-1 text-sm ${
+          isValidLoginInfo ? 'invisible' : 'visible'
+        }`}
         style={{ fontFamily: 'noto-bold, sans-serif' }}
       >
-        유효하지 않은 사원번호 또는 비밀번호 입니다.
+        유효하지 않은 사원번호 또는 비밀번호입니다.
       </div>
       <Button className='bg-hanaindigo text-xl' type='submit'>
         로그인

--- a/src/containers/PbProfile.tsx
+++ b/src/containers/PbProfile.tsx
@@ -1,31 +1,31 @@
 import { Switch } from '@radix-ui/react-switch';
 import { useState, useRef, useEffect } from 'react';
-import PbJsonData from '../../public/data/PB.json';
+// import PbJsonData from '../../public/data/PB.json';
 import Section from '../components/Section';
-import { useSession } from '../hooks/sessionContext';
+// import { useSession } from '../hooks/sessionContext';
 import { type TPbProps } from '../types/dataTypes';
 
 export default function PbProfile() {
-  const { user } = useSession();
-  const allPbData = PbJsonData;
+  // const { pbData } = useSession();
+  // const allPbData = PbJsonData;
 
   const [profile, setProfile] = useState<TPbProps | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isAvailable, setIsAvailable] = useState(false);
-  const [image, setImage] = useState(user?.image_url);
+  // const [image, setImage] = useState(pbData?.imageUrl);
   const fileInput = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    const userData = allPbData.find(
-      ({ login_id }) => login_id === user?.login_id
-    );
+  // useEffect(() => {
+  //   const pbData = allPbData.find(
+  //     ({ login_id }) => login_id === pbData?.login_id
+  //   );
 
-    if (userData) {
-      setProfile(userData);
-      setImage(userData.image_url);
-      setIsAvailable(userData.availability);
-    }
-  }, [user, allPbData]);
+  //   if (pbData) {
+  //     setProfile(pbData);
+  //     setImage(pbData.image_url);
+  //     setIsAvailable(pbData.availability);
+  //   }
+  // }, [pbData, allPbData]);
 
   // 빠른 상담 가능 여부 토글
   const handleAvailabilityChange = (checked: boolean) => {

--- a/src/hooks/sessionContext.tsx
+++ b/src/hooks/sessionContext.tsx
@@ -1,9 +1,7 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
-import { type TPbProps } from '../types/dataTypes';
+import React, { createContext, useContext, useState } from 'react';
+import { type TPbDataProps } from '../types/dataTypes';
 
 type SessionContextType = {
-  user: TPbProps | null;
-  handleLoginEvent: (userData: TPbProps) => void;
   handleLogoutEvent: () => void;
 };
 
@@ -16,24 +14,11 @@ export const SessionProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [user, setUser] = useState<TPbProps | null>(null);
-
-  useEffect(() => {
-    const storedUser = localStorage.getItem('user');
-    if (storedUser) {
-      setUser(JSON.parse(storedUser));
-    }
-  }, []);
-
-  const handleLoginEvent = (userData: TPbProps) => {
-    setUser(userData);
-    localStorage.setItem('user', JSON.stringify(userData));
-    alert('오늘 하루도 힘내세요!😊🍀');
-  };
+  const [_, setPbData] = useState<TPbDataProps | null>(null);
 
   const handleLogoutEvent = () => {
-    setUser(null);
-    localStorage.removeItem('user');
+    setPbData(null);
+    localStorage.removeItem('loginPB');
     alert('오늘 하루도 고생하셨습니다!😊🎉');
     window.location.reload();
   };
@@ -41,8 +26,6 @@ export const SessionProvider = ({
   return (
     <SessionContext.Provider
       value={{
-        user,
-        handleLoginEvent,
         handleLogoutEvent,
       }}
     >

--- a/src/hooks/useFetch.tsx
+++ b/src/hooks/useFetch.tsx
@@ -3,11 +3,13 @@ import { useEffect, useState } from 'react';
 type TUseFetchResult<T> = {
   data: T | null;
   error: Error | null;
+  fetchData?: () => Promise<void>;
 };
 
 export default function useFetch<T>(
   url: string,
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET'
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET',
+  body?: Record<string, any>
 ): TUseFetchResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -16,15 +18,21 @@ export default function useFetch<T>(
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const fetchHeaders = {
+        const fetchHeaders: Record<string, string> = {
           'Content-Type': 'application/json',
-          // 추후 로그인 인증 추가할 것
         };
 
         const response = await fetch(`${APIKEY}/${url}`, {
           method,
           headers: fetchHeaders,
+          credentials: 'include',
+          body: body ? JSON.stringify(body) : undefined,
         });
+
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
         const data = await response.json();
         setData(data);
       } catch (err) {
@@ -36,3 +44,26 @@ export default function useFetch<T>(
 
   return { data, error };
 }
+
+// useEffect(() => {
+//   const fetchData = async () => {
+//     try {
+//       const fetchHeaders = {
+//         'Content-Type': 'application/json',
+//         withCredentials: true,
+//       };
+
+//       const response = await fetch(`${APIKEY}/${url}`, {
+//         method,
+//         headers: fetchHeaders,
+//       });
+//       const data = await response.json();
+//       setData(data);
+//     } catch (err) {
+//       setError(err as Error);
+//     }
+//   };
+//   fetchData();
+// }, [url]);
+
+// return { data, error };

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -25,12 +25,12 @@ export type TConsultingProps = {
 };
 
 // [x] PB 개인정보 타입 (PB.json)
-export type TPbProps = {
+export type TPbDataProps = {
   id: number;
-  login_id: string;
+  loginId: string;
   password: string;
   name: string;
-  image_url: string;
+  imageUrl: string;
   introduce: string;
   office: string;
   tags: string[];


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #156 

## 💻 작업 내용

> 기존에 sessionContext에서 user정보와 handleLoginEvent를 전역관리하던 것을
Login컨테이너에서 처리하는 것으로 변경함

> 로그인 이벤트는 로그인화면에서밖에 이루지지 않고, 
/pb/login POST api를 통해 localStorage에 'loginPB'라는 key값이 생성(value는 undefined)된 것만 확인되면 되기 때문

> 그외에 useFetch 커스텀훅의 수정에 대해 고민함

## 💬 리뷰 요구사항(선택)
