### PR TITLE
[feat] : 상담 일지 리스트 조회와 상담 일지를 클릭하면 나오는 내용들을 연결하였습니다.

### DIFF
--- a/src/components/ConsultationJournalListItem.tsx
+++ b/src/components/ConsultationJournalListItem.tsx
@@ -15,21 +15,21 @@ export const ConsultationJournalListItem = ({
     <div
       onClick={() => openNewWindow(consultation)}
       className='bg-white rounded-lg p-4 mb-4 shadow-lg flex items-center border justify-around border-gray-200 cursor-pointer'
-    >
+      >
       <div className='w-full flex items-center justify-between'>
         <div className='w-2/3 flex justify-between items-center'>
-          <span className='text-hanaindigo mr-4'>{index + 1}</span>
+          <span className='text-hanaindigo mr-4'>{index}</span>
 
           <div className='w-[80%] flex flex-col justify-between'>
             <div
               className='truncate'
-              title={consultation.title}
+              title={consultation.consultTitle}
               style={{ fontFamily: 'noto-bold, sans-serif' }}
             >
-              {consultation.title}
+              {consultation.consultTitle}
             </div>
             <span style={{ fontFamily: 'noto-light, sans-serif' }}>
-              {consultation.pb_id} PB
+              {consultation.pbName} PB
             </span>
           </div>
         </div>
@@ -38,7 +38,7 @@ export const ConsultationJournalListItem = ({
           className='w-1/3 flex justify-end items-center'
           style={{ fontFamily: 'noto-light, sans-serif' }}
         >
-          {consultation.date}
+          {consultation.consultDate}
         </span>
       </div>
     </div>

--- a/src/containers/ConsultationJournalList.tsx
+++ b/src/containers/ConsultationJournalList.tsx
@@ -1,72 +1,47 @@
-import { createRoot } from 'react-dom/client';
 import { useParams } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ConsultationJournalListItem } from '../components/ConsultationJournalListItem';
 import { SearchField } from '../components/SearchField';
 import Section from '../components/Section';
 import useDebounce from '../hooks/useDebounce';
 import ReadJournalWindow from '../pages/ReadJournalWindow';
-import { type TPbProps, type TJournalsProps } from '../types/dataTypes';
+import useFetch from '../hooks/useFetch';
+import { type TJournalsProps } from '../types/dataTypes';
+import { createRoot } from 'react-dom/client';
 
 export default function ConsultationJournalList() {
+  // URL에서 id 파라미터를 가져옴
   const { id } = useParams();
-  const [consultationJourData, setConsultationJourData] = useState<
-    TJournalsProps[]
-  >([]);
+
   const [searchTerm, setSearchTerm] = useState('');
-  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+  const debouncedSearchTerm = useDebounce(searchTerm, 500); // 디바운싱 처리된 검색어
 
-  const fetchPBName = async (pbId: number): Promise<string> => {
-    try {
-      const response = await fetch('/data/PB.json');
-      const pbData = await response.json();
-      const pb = pbData.find((pb: TPbProps) => pb.id === pbId);
-
-      return pb ? pb.name : 'PB 이름 없음';
-    } catch (error) {
-      alert('Error fetching PB data:');
-      return 'PB 이름 없음';
-    }
-  };
-
-  const fetchConsultationData = async () => {
-    try {
-      const response = await fetch('/data/Journals.json');
-      const data: TJournalsProps[] = await response.json();
-
-      const filteredData = await Promise.all(
-        data
-          .filter((consultation) => consultation.customer_id === Number(id))
-          .map(async (consultation) => {
-            const pbName = await fetchPBName(consultation.pb_id);
-            return { ...consultation, pbName };
-          })
-      );
-
-      setConsultationJourData(filteredData);
-    } catch (error) {
-      alert('Error fetching consultation data:');
-    }
-  };
+  // 상담일지 데이터를 가져오는 useFetch 훅
+  const { data: consultationData, error: consultationError } = useFetch<TJournalsProps[]>('pb/journals');
+  console.error(consultationError);
+  
+  // 상담일지 데이터를 상태로 관리
+  const [filteredConsultationData, setConsultationData] = useState<TJournalsProps[]>([]);
 
   useEffect(() => {
-    if (id !== null) {
-      fetchConsultationData();
-    }
-  }, [id]);
-
-  // 상담일지 검색하기
-  const filteredJournal = consultationJourData.filter(
-    ({ title, content }) =>
-      title.toLowerCase().includes(debouncedSearchTerm.toLowerCase()) ||
-      content.toLowerCase().includes(debouncedSearchTerm.toLowerCase())
+  if (consultationData) {
+    const filteredData = consultationData.filter(
+      (consultation) => consultation.customerId === Number(id)
+    );
+    setConsultationData(filteredData); // 상태 업데이트
+  }
+  
+}, [consultationData, id]);
+  // 상담일지 검색
+  const filteredJournal = filteredConsultationData.filter(
+    ({ consultTitle }) =>
+      consultTitle && consultTitle.includes(debouncedSearchTerm) // title이 존재할 때만 includes 실행
   );
-
-  // 상담일지 자세히보기
+  // 상담일지를 새 창에서 자세히 보기
   const openNewWindow = (consultation: TJournalsProps) => {
     const newWindow = window.open('', '_blank', 'width=800,height=600');
-
     if (newWindow) {
+      // 현재 페이지의 스타일을 새 창에 적용
       const styles = Array.from(document.styleSheets)
         .map((styleSheet) => {
           try {
@@ -98,31 +73,36 @@ export default function ConsultationJournalList() {
       const rootElement = newWindow.document.getElementById('journal-root');
       if (rootElement) {
         const root = createRoot(rootElement);
-        root.render(<ReadJournalWindow consultation={consultation} />);
+        root.render(<ReadJournalWindow consultation={consultation} />); // 새 창에서 상담일지 보기
       }
     }
   };
 
+  
   return (
     <Section title='상담일지 리스트' layoutClassName='h-full'>
       <div className='sticky top-0 z-10 w-full bg-white'>
+        {/* 검색창 */}
         <SearchField
           placeholder='상담일지 검색'
           value={searchTerm}
           onChange={setSearchTerm}
         />
       </div>
-
+      
       <div className='p-4'>
-        {filteredJournal.length > 0 ? (
-          filteredJournal.map((consultation, index) => (
-            <ConsultationJournalListItem
-              key={index}
-              index={consultation.id || index}
-              consultation={consultation}
-              openNewWindow={openNewWindow}
-            />
-          ))
+        {/* 필터링된 상담일지를 표시 */}
+        {filteredJournal.length ? (
+          filteredJournal.map((consultation, index) => {
+            return (
+              <ConsultationJournalListItem
+                key={index}
+                index={index+1}
+                consultation={consultation}
+                openNewWindow={openNewWindow}
+              />
+            );
+          })
         ) : (
           <div className='text-center text-hanaindigo text-xl'>
             상담 일지가 없습니다.

--- a/src/pages/ReadJournalWindow.tsx
+++ b/src/pages/ReadJournalWindow.tsx
@@ -1,55 +1,24 @@
-import { useEffect, useState } from 'react';
-import mockupScript from '../assets/mockupScript.png';
-import { type TCategoryProps } from '../types/dataTypes';
+import { type TScriptProps } from '../types/dataTypes';
 import { type TJournalsProps } from '../types/dataTypes';
-import { type TCustomerProps } from '../types/dataTypes';
+import useFetch from '../hooks/useFetch';
 
+// consultation 타입 
 type TPbJournalsProps = {
   consultation: TJournalsProps;
 };
 
+// 스크립트 응답 데이터 타입
+export type TScriptResponseProps = {
+  scriptResponseDTOList: TScriptProps[];
+};
+
 export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
-  const [categoryName, setCategoryName] = useState<string>('');
-  const [_, setCustomerName] = useState<string>('');
-
-  // 카테고리 이름 불러오기 함수
-  const fetchCategoryName = async (categoryId: number) => {
-    try {
-      const response = await fetch('/data/Category.json');
-      const categoryData: TCategoryProps[] = await response.json();
-      const category = categoryData.find(({ id }) => id === categoryId);
-
-      if (category) {
-        setCategoryName(category.name);
-      }
-    } catch (error) {
-      console.error('Error fetching category data:');
-    }
-  };
-
-  // 손님 이름 불러오기 함수
-  const fetchCustomerName = async (customerId: number) => {
-    try {
-      const response = await fetch('/data/Customers.json');
-      const customerData: TCustomerProps[] = await response.json();
-      const customer = customerData.find(({ id }) => id === customerId);
-
-      if (customer) {
-        setCustomerName(customer.name);
-      }
-    } catch (error) {
-      console.error('Error fetching customer data:');
-    }
-  };
-
-  useEffect(() => {
-    if (consultation.category_id) {
-      fetchCategoryName(consultation.category_id);
-    }
-    if (consultation.customer_id) {
-      fetchCustomerName(consultation.customer_id);
-    }
-  }, [consultation.category_id, consultation.customer_id]);
+  
+  // 스크립트 데이터를 API에서 가져오는 useFetch 훅
+  const { data: scriptData = { scriptResponseDTOList: [] }, error: scriptError } = useFetch<TScriptResponseProps>(
+    `pb/journals/${consultation.id}/scripts`
+  );
+  console.error(scriptError);
 
   return (
     <div className='flex items-start justify-center w-full h-full space-x-4 overflow-y-auto'>
@@ -57,7 +26,6 @@ export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
         <div className='sticky top-0 bg-hanaindigo text-white text-[1.5rem] font-extrabold p-4 rounded-t-lg pl-5'>
           상담일지 자세히보기
         </div>
-
         <div className='p-10 space-y-4 flow-y-auto bg-white'>
           <div className='flex justify-between items-center border-b border-black py-1'>
             <label className='text-xs'>[상담 제목]</label>
@@ -65,7 +33,7 @@ export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
               className='flex justify-between items-center text-sm w-[84%] pl-2 focus:outline-none rounded-xl'
               style={{ fontFamily: 'noto-bold, sans-serif' }}
             >
-              <span>{consultation.title}</span>
+              <span>{consultation.consultTitle}</span>
             </div>
           </div>
           <div className='flex justify-start items-center border-b border-black py-1 space-x-2'>
@@ -75,7 +43,7 @@ export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
                 className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                 style={{ fontFamily: 'noto-bold, sans-serif' }}
               >
-                {categoryName}
+                {consultation.categoryName}
               </div>
             </div>
             <div className='flex items-center justify-between w-1/2'>
@@ -84,7 +52,7 @@ export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
                 className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                 style={{ fontFamily: 'noto-bold, sans-serif' }}
               >
-                {consultation.date}
+                {consultation.consultDate}
               </div>
             </div>
           </div>
@@ -92,19 +60,47 @@ export default function ReadJournalWindow({ consultation }: TPbJournalsProps) {
             <div>
               <span className='text-sm mb-3'>[PB의 기록]</span>
               <div className='w-full h-40 p-2 border resize-none overflow-y-auto'>
-                {consultation.content}
+                {consultation.contents}
               </div>
             </div>
             <div>
               <span className='text-sm mb-3'>[PB의 추천 상품]</span>
               <div className='w-full h-40 p-2 border resize-none overflow-y-auto'>
-                {consultation.content}
+                {consultation.journalProduct.map((product, index) => (
+                  <div key={index} className="flex space-x-4 mb-2">
+                    <img src={product.image_url} alt={product.name} className="w-16 h-16 object-cover" />
+                    <div className="flex flex-col justify-center">
+                      <a href={product.product_url} target="_blank" rel="noopener noreferrer" className="text-blue-500 text-sm">{product.name}</a>
+                    </div>
+                  </div>
+                ))}
               </div>
             </div>
             <div>
               <span className='text-sm mb-3'>[상담 스크립트]</span>
-              <div className='flex justify-center w-full h-96 p-2 border resize-none overflow-y-auto'>
-                <img src={mockupScript} alt='상담 내용' />
+              <div className="chat-container w-full p-4 border rounded-lg overflow-y-auto space-y-3 bg-gray-100">
+                {scriptData?.scriptResponseDTOList ? (
+                  scriptData.scriptResponseDTOList.map((script) => (
+                    <div
+                      key={script.scriptId}
+                      className={`chat-message flex ${
+                        script.speaker === 'PB' ? 'justify-start' : 'justify-end'
+                      }`}
+                    >
+                      <div
+                        className={`chat-bubble max-w-[60%] p-3 rounded-xl shadow-md ${
+                          script.speaker === 'PB'
+                            ? 'bg-indigo-200 text-black rounded-bl-none'
+                            : 'bg-gray-200 text-black rounded-br-none'
+                        }`}
+                      >
+                        <p className="text-sm font-medium">{script.content}</p>
+                      </div>
+                    </div>
+                  ))
+                ) : (
+                  <div>스크립트 데이터를 불러오는 중입니다...</div>
+                )}
               </div>
             </div>
           </div>

--- a/src/types/dataTypes.ts
+++ b/src/types/dataTypes.ts
@@ -2,11 +2,31 @@
 export type TJournalsProps = {
   id: number;
   pb_id: number; // 작성한 pb ID
-  customer_id: number;
-  category_id: number;
+  customerId: number;
+  categoryId: number;
   status_id: number;
-  title: string;
-  date: string;
+  pbName: string;
+  consultTitle: string;
+  consultDate: string;
+  contents: string;
+  categoryName: string;
+  journalProduct: TJournalProduct[];
+};
+
+// 추천 상품 타입
+type TJournalProduct = {
+  id: number | null;
+  name: string;
+  product_url: string;
+  image_url: string;
+  journalProduct: any[];
+};
+
+// 스크립트 타입
+export type TScriptProps = {
+  scriptId: number;
+  scriptSequence: number;
+  speaker: string;
   content: string;
 };
 


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #172 
> #173 

## 💻 작업 내용

> customerDetail페이지에서 해당 손님의 id의 맞는 상담 일지들이 나오겠끔 하였고,
해당 상담 일지를 클릭하면 카테고리, PB의 기록, PB의 추천 상품, 상담 스크립트가 나오게 연결하였습니다(백엔드도 수정이 있어서, 백도 pr날립니다!)
