### PR TITLE
[feat] : 상담 일지 저장 추가(추천 상품 제외)

### DIFF
--- a/src/containers/MakeJournal.tsx
+++ b/src/containers/MakeJournal.tsx
@@ -5,7 +5,7 @@ import { Button } from '../components/ui/button';
 import RequestContentPage from '../pages/RequestContentPage';
 import { useParams } from 'react-router-dom';
 import useFetch from '../hooks/useFetch';
-import { TConsultationProps } from '../types/dataTypes';
+import { type TConsultationProps } from '../types/dataTypes';
 const APIKEY = import.meta.env.VITE_API_KEY;
 
 export default function MakeJournal() {
@@ -23,6 +23,7 @@ export default function MakeJournal() {
 
   const [day, setDay] = useState<string>();
   const [time, setTime] = useState<string>();
+  
   useEffect(() => {
     if (data) {
       const selectedConsultation = data.find((consultation) => consultation.id === Number(id));
@@ -36,7 +37,7 @@ export default function MakeJournal() {
   }, [data, id]); 
 
   const openNewWindow = (id: string) => {
-    const newWindow = window.open('', '_blank', 'width=800,height=600');
+    const newWindow = window.open('', '_blank', 'width=800, height=600');
     if (newWindow) {
       const styles = Array.from(document.styleSheets)
         .map((styleSheet) => {
@@ -50,6 +51,7 @@ export default function MakeJournal() {
           }
         })
         .join('');
+      
       newWindow.document.write(`
         <html lang="en">
         <head>
@@ -147,7 +149,7 @@ export default function MakeJournal() {
                   className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                   style={{ fontFamily: 'noto-bold, sans-serif' }}
                 >
-                  손흥민 PB
+                  {PB 이름} PB
                 </div>
               </div>
               <div className='flex items-center space-x-3 w-1/3'>
@@ -156,7 +158,8 @@ export default function MakeJournal() {
                   className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                   style={{ fontFamily: 'noto-bold, sans-serif' }}
                 >
-                  {day}  {time}
+                  // changeDateFormat 함수 감쌀 것
+                  {day} {time}
                 </div>
               </div>
             </div>

--- a/src/containers/MakeJournal.tsx
+++ b/src/containers/MakeJournal.tsx
@@ -1,15 +1,42 @@
+import { useState, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import Section from '../components/Section';
 import { Button } from '../components/ui/button';
 import RequestContentPage from '../pages/RequestContentPage';
 import { useParams } from 'react-router-dom';
+import useFetch from '../hooks/useFetch';
+import { TConsultationProps } from '../types/dataTypes';
+const APIKEY = import.meta.env.VITE_API_KEY;
 
 export default function MakeJournal() {
   const { id } = useParams();
-  // 요청내용 상세보기
+
+  const { data, error } = useFetch<TConsultationProps[]>(`pb/reserves?status=true&type=upcoming`);
+  if (error){
+    console.error(error);
+  }
+
+  const [categoryId, setCategoryId] = useState<number>(1);
+  const [consultingTitle, setConsultingTitle] = useState<string | undefined>(undefined);
+  const [journalContents, setJournalContents] = useState<string>();
+  const [recommendedProductsKeys, setRecommendedProductsKeys] = useState<number[]>([]);
+
+  const [day, setDay] = useState<string>();
+  const [time, setTime] = useState<string>();
+  useEffect(() => {
+    if (data) {
+      const selectedConsultation = data.find((consultation) => consultation.id === Number(id));
+      if (selectedConsultation) {
+        setConsultingTitle(selectedConsultation.title);
+        setCategoryId(selectedConsultation.categoryId);
+        setDay(selectedConsultation.hopeDate);
+        setTime(selectedConsultation.hopeTime?.slice(0, -3));
+      }
+    }
+  }, [data, id]); 
+
   const openNewWindow = (id: string) => {
     const newWindow = window.open('', '_blank', 'width=800,height=600');
-
     if (newWindow) {
       const styles = Array.from(document.styleSheets)
         .map((styleSheet) => {
@@ -23,27 +50,53 @@ export default function MakeJournal() {
           }
         })
         .join('');
-
       newWindow.document.write(`
         <html lang="en">
-          <head>
-            <meta charset="UTF-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <title>쪽지 자세히 보기</title>
-            <style>${styles}</style>
-          </head>
-          <body>
-            <div id="dictionary-root"></div>
-          </body>
+        <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>쪽지 자세히 보기</title>
+        <style>${styles}</style>
+        </head>
+        <body>
+        <div id="dictionary-root"></div>
+        </body>
         </html>
       `);
       newWindow.document.close();
-
+      
       const rootElement = newWindow.document.getElementById('dictionary-root');
       if (rootElement) {
         const root = createRoot(rootElement);
         root.render(<RequestContentPage id={id} />);
       }
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const requestBody = {
+      consultingId: id,
+      categoryId,
+      consultingTitle,
+      journalContents,
+      recommendedProductsKeys,
+    };
+
+    try {
+      const response = await fetch(`${APIKEY}/pb/journals/transfer`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (response.ok) {
+        alert('상담 일지가 전송되었습니다.');
+      } 
+    } catch (error) {
+      console.error(error);
     }
   };
 
@@ -56,7 +109,9 @@ export default function MakeJournal() {
             <div className='w-full flex items-center space-x-3 border-b border-black py-1'>
               <label className='text-xs'>[상담 제목]</label>
               <input
-                defaultValue='빠른 상담 요청'
+                value={consultingTitle}
+                onChange={(e) => setConsultingTitle(e.target.value)}
+                defaultValue={consultingTitle}
                 type='text'
                 maxLength={50}
                 className='text-sm flex-grow focus:outline-none'
@@ -72,12 +127,18 @@ export default function MakeJournal() {
             <div className='flex justify-start items-center border-b border-black py-1 space-x-2'>
               <div className='flex items-center space-x-3 w-1/3'>
                 <label className='text-xs'>[카테고리]</label>
-                <select name='category' id='category' className='text-sm'>
-                  <option value='quick'>빠른상담</option>
-                  <option value='silver'>은퇴설계</option>
-                  <option value='asset'>자산관리</option>
-                  <option value='care'>주거/케어</option>
-                  <option value='life'>라이프</option>
+                <select
+                  value={categoryId}
+                  onChange={(e) => setCategoryId(Number(e.target.value))}
+                  name='category'
+                  id='category'
+                  className='text-sm'
+                >
+                  <option value={1}>빠른상담</option>
+                  <option value={2}>은퇴설계</option>
+                  <option value={3}>자산관리</option>
+                  <option value={4}>주거/케어</option>
+                  <option value={5}>라이프</option>
                 </select>
               </div>
               <div className='flex items-center space-x-3 w-1/3'>
@@ -86,7 +147,7 @@ export default function MakeJournal() {
                   className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                   style={{ fontFamily: 'noto-bold, sans-serif' }}
                 >
-                  조경은 PB
+                  손흥민 PB
                 </div>
               </div>
               <div className='flex items-center space-x-3 w-1/3'>
@@ -95,7 +156,7 @@ export default function MakeJournal() {
                   className='text-sm w-2/3 px-2 focus:outline-none rounded-xl'
                   style={{ fontFamily: 'noto-bold, sans-serif' }}
                 >
-                  2024.12.01 13:50
+                  {day}  {time}
                 </div>
               </div>
             </div>
@@ -105,11 +166,17 @@ export default function MakeJournal() {
           <div className='flex flex-col space-y-10 h-full'>
             <div className='h-2/5 mb-4'>
               <div className='text-sm mb-3'>[PB의 기록]</div>
-              <textarea className='w-full h-full p-2 border resize-none text-sm overflow-y-auto focus:outline-hanasilver' />
+              <textarea
+                value={journalContents}
+                onChange={(e) => setJournalContents(e.target.value)}
+                className='w-full h-full p-2 border resize-none text-sm overflow-y-auto focus:outline-hanasilver'
+              />
             </div>
             <div className='h-2/5'>
               <div className='text-sm mb-3'>[PB의 추천 상품]</div>
-              <textarea className='w-full h-full p-2 border resize-none text-sm overflow-y-auto focus:outline-hanasilver' />
+              <textarea
+                className='w-full h-full p-2 border resize-none text-sm overflow-y-auto focus:outline-hanasilver'
+              />
             </div>
           </div>
         </div>
@@ -122,7 +189,11 @@ export default function MakeJournal() {
             </Button>
           </div>
           <div>
-            <Button className='bg-hanaindigo w-20 px-2 rounded-xl'>전송</Button>
+            <form id="journalForm" onSubmit={handleSubmit}>
+              <Button type="submit" className='bg-hanaindigo w-20 px-2 rounded-xl'>
+                전송
+              </Button>
+            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #181 

## 💻 작업 내용

> 상담일지를 저장(전송)하는 기능을 하였습니다. pb/journals/transfer 
제목과 카테고리, 시간은 consulting테이블에서 불러왔습니다!

* 상품에 대해서는 어떻게 보낼지가 애매합니다!!
(숫자로 1 이렇게 하나 입력하면 보내지기는하는데 - 여기까지만 되어있습니다!)