### PR TITLE
Feature/post/pb/logout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,9 +15,18 @@ import MainPage from './pages/MainPage';
 import NotFoundPage from './pages/NotFoundPage';
 import NotificationPage from './pages/NotificationPage';
 
+// const getCookie = (name: string) => {
+//   const value = `; ${document.cookie}`;
+//   const parts = value.split(`; ${name}=`);
+//   if (parts.length === 2) return parts.pop()?.split(';').shift();
+//   return undefined;
+// };
+
 const ProtectedLayout = () => {
   const navigate = useNavigate();
   const isLogin = localStorage.getItem('loginPB');
+  // const navigate = useNavigate();
+  // const isLogin = getCookie('JSESSIONID');
 
   useEffect(() => {
     if (!isLogin) {

--- a/src/components/JournalProductInputArea.tsx
+++ b/src/components/JournalProductInputArea.tsx
@@ -17,26 +17,16 @@ export default function JournalProductInputArea({
   const listRef = useRef<HTMLUListElement | null>(null);
 
   const { data: productList } = useFetch<{ id: number; productName: string }[]>(
-    debouncedSearchTerm && `pb/journals/products?tag=${debouncedSearchTerm}`
+    debouncedSearchTerm && `journals/products?tag=${debouncedSearchTerm}`
   );
 
   const [selectedProducts, setSelectedProducts] = useState<string[]>([]);
   const [isListVisible, setIsListVisible] = useState(false);
 
-  // const handleProductSelect = (productName: string, productId: number) => {
-  //   if (!selectedProducts.includes(productName)) {
-  //     setSelectedProducts((prev) => [...prev, productName]);
-  //     setRecommendedProductsKeys((prev) => [...prev, productId]);
-  //   }
-  //   setInputValue('');
-  //   setIsListVisible(false);
-  // };
-  // // console.log('recommendedProductsKeys: ', recommendedProductsKeys);
-
   const handleProductSelect = (productName: string, productId: number) => {
     if (!selectedProducts.includes(productName)) {
       setSelectedProducts((prev) => [...prev, productName]);
-      setRecommendedProductsKeys((prev) => [...prev, productId]); // 부모 상태 업데이트
+      setRecommendedProductsKeys((prev) => [...prev, productId]);
     }
     setInputValue('');
     setIsListVisible(false);

--- a/src/components/RequestedConsultationItem.tsx
+++ b/src/components/RequestedConsultationItem.tsx
@@ -22,7 +22,7 @@ export const RequestedConsultationItem = ({
     return categoryId === 1 ? 'quick-border' : 'border-gray-200';
   };
 
-  const { error, fetchData } = useFetch(`pb/reserves?id=${id}`, 'PUT');
+  const { error, fetchData } = useFetch(`reserves?id=${id}`, 'PUT');
   console.log('들어온 상담요청 승인 중 발생한 에러: ', error);
 
   const approveRequestEvent = async () => {

--- a/src/containers/ApprovedConsultationsList.tsx
+++ b/src/containers/ApprovedConsultationsList.tsx
@@ -27,7 +27,9 @@ export default function ApprovedConsultationsList({
   // 손님 한 명에 대한 정보 조회하기 위함
   const filteredConsultations = id
     ? approvedConsultations.filter(
-        (consultation) => consultation.customerName === customerName
+        (consultation) =>
+          consultation.customerName.toLowerCase() ===
+          customerName?.toLowerCase()
       )
     : approvedConsultations;
 

--- a/src/containers/ApprovedConsultationsList.tsx
+++ b/src/containers/ApprovedConsultationsList.tsx
@@ -12,7 +12,7 @@ export default function ApprovedConsultationsList({
 }) {
   const { id } = useParams();
   const { data, error } = useFetch<TConsultationProps[]>(
-    `pb/reserves?status=true&type=upcoming`
+    `reserves?status=true&type=upcoming`
   );
   console.error('예정된 상담요청 조회 중 발생한 에러: ', error);
 

--- a/src/containers/ConsultationJournalList.tsx
+++ b/src/containers/ConsultationJournalList.tsx
@@ -39,7 +39,8 @@ export default function ConsultationJournalList({
   // 한 손님의 모든 상담일지 중 검색
   const filteredJournalsList = customerJournalsListData.filter(
     ({ consultTitle }) =>
-      consultTitle && consultTitle.includes(debouncedSearchTerm)
+      consultTitle &&
+      consultTitle.toLowerCase().includes(debouncedSearchTerm.toLowerCase())
   );
 
   // 상담일지를 새 창에서 자세히 보기

--- a/src/containers/ConsultationJournalList.tsx
+++ b/src/containers/ConsultationJournalList.tsx
@@ -9,16 +9,17 @@ import useFetch from '../hooks/useFetch';
 import ReadJournalWindow from '../pages/ReadJournalWindow';
 import { type TJournalsProps } from '../types/dataTypes';
 
-export default function ConsultationJournalList() {
-  // customerId
-  const { id } = useParams();
-
+export default function ConsultationJournalList({
+  customerId,
+}: {
+  customerId: number;
+}) {
   const [searchTerm, setSearchTerm] = useState('');
   const debouncedSearchTerm = useDebounce(searchTerm, 500);
 
   // PB의 모든 상담일지 조회
   const { data: consultationData, error: consultationError } =
-    useFetch<TJournalsProps[]>('pb/journals');
+    useFetch<TJournalsProps[]>('journals');
   console.error('상담일지 리스트 조회 중 발생한 에러: ', consultationError);
 
   // 한 손님의 모든 상담일지 조회
@@ -29,11 +30,11 @@ export default function ConsultationJournalList() {
   useEffect(() => {
     if (consultationData) {
       const customerJournalsList = consultationData.filter(
-        (consultation) => consultation.customerId === Number(id)
+        (consultation) => consultation.customerId === customerId
       );
       setCustomerJournalsListData(customerJournalsList);
     }
-  }, [consultationData, id]);
+  }, [consultationData, customerId]);
 
   // 한 손님의 모든 상담일지 중 검색
   const filteredJournalsList = customerJournalsListData.filter(

--- a/src/containers/CustomerInformation.tsx
+++ b/src/containers/CustomerInformation.tsx
@@ -14,7 +14,7 @@ export default function CustomerInformation({
   const [memoData, setMemoData] = useState<string>(customerData?.memo || '');
 
   const { fetchData } = useFetch<string>(
-    `pb/customers/${customerData?.id}/memo`,
+    `customers/${customerData?.id}/memo`,
     'POST'
   );
 

--- a/src/containers/CustomerList.tsx
+++ b/src/containers/CustomerList.tsx
@@ -16,7 +16,7 @@ export default function CustomerList() {
   const listRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const { data: initialData, error: initialError } =
-    useFetch<TCustomerProps[]>(`pb/customers/list`);
+    useFetch<TCustomerProps[]>(`customers/list`);
 
   const { data: searchData, error: searchError } = useFetch<TCustomerProps[]>(
     debouncedSearchTerm && `pb/customers/search?name=${debouncedSearchTerm}`

--- a/src/containers/Login.tsx
+++ b/src/containers/Login.tsx
@@ -16,7 +16,7 @@ export default function Login() {
     const password = passwordRef.current?.value || '';
 
     try {
-      const response = await fetch(`${import.meta.env.VITE_API_KEY}/pb/login`, {
+      const response = await fetch(`${import.meta.env.VITE_API_KEY}login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/containers/MakeJournal.tsx
+++ b/src/containers/MakeJournal.tsx
@@ -16,7 +16,7 @@ export default function MakeJournal() {
   const pbName = JSON.parse(localStorage.getItem('loginPB') || '{}').name;
 
   const { data, error } = useFetch<TConsultationProps[]>(
-    `pb/reserves?status=true&type=upcoming`
+    `reserves?status=true&type=upcoming`
   );
 
   const [categoryId, setCategoryId] = useState<number>(1);

--- a/src/containers/NotificationHistory.tsx
+++ b/src/containers/NotificationHistory.tsx
@@ -18,12 +18,12 @@ export default function NotificationHistory() {
   // 쪽지 연결
   const [notifications, setNotifications] = useState<TNotificationProps[]>([]);
   const { data: notificationsData, error: notificationsError } =
-    useFetch<TNotificationProps[]>('pb/notifications');
+    useFetch<TNotificationProps[]>('notifications');
 
   // 고객 연결
   const [customers, setCustomers] = useState<TCustomerProps[]>([]);
   const { data: customersData, error: customersError } =
-    useFetch<TCustomerProps[]>(`pb/customers/list`);
+    useFetch<TCustomerProps[]>(`customers/list`);
 
   useEffect(() => {
     if (notificationsData) {
@@ -102,8 +102,8 @@ export default function NotificationHistory() {
   // 동적으로 생성된 URL
   const searchUrl =
     selectedIds.length > 0
-      ? `pb/notifications/search?${searchParams.toString()}`
-      : 'pb/notifications';
+      ? `notifications/search?${searchParams.toString()}`
+      : 'notifications';
 
   const { data: filteredNotifications, error: filteredNotificationsError } =
     useFetch<TNotificationProps[]>(searchUrl);
@@ -118,13 +118,11 @@ export default function NotificationHistory() {
   const openNewWindow = async (notificationId: number) => {
     try {
       const baseUrl = import.meta.env.VITE_API_KEY;
-      const url = `${baseUrl}/pb/notifications/${notificationId}`;
+      const url = `${baseUrl}notifications/${notificationId}`;
 
-      const response = await fetch(url,
-      {
-        credentials: 'include',  
-      }
-      );
+      const response = await fetch(url, {
+        credentials: 'include',
+      });
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }

--- a/src/containers/PbCalendar.tsx
+++ b/src/containers/PbCalendar.tsx
@@ -24,7 +24,7 @@ export default function PbCalendar() {
   const modalExternal = useRef<HTMLDivElement>(null);
 
   const { data, error } = useFetch<TConsultationProps[]>(
-    `pb/reserves?status=true&type=upcoming`
+    `reserves?status=true&type=upcoming`
   );
   if (error) {
     console.error('승인된 상담 일정 조회 중 발생한 에러: ', error);

--- a/src/containers/PbProfile.tsx
+++ b/src/containers/PbProfile.tsx
@@ -5,7 +5,7 @@ import useFetch from '../hooks/useFetch';
 import { type TPbDataProps } from '../types/dataTypes';
 
 export default function PbProfile() {
-  const { data, error } = useFetch<TPbDataProps>('pb/profile');
+  const { data, error } = useFetch<TPbDataProps>('profile');
   const [pbData, setPbData] = useState<TPbDataProps | null>(null);
   const [isEditing, setIsEditing] = useState(false);
   const [isAvailable, setIsAvailable] = useState(false);

--- a/src/containers/RequestedConsultationsList.tsx
+++ b/src/containers/RequestedConsultationsList.tsx
@@ -7,7 +7,7 @@ import { TConsultationProps } from '../types/dataTypes';
 
 export default function RequestedConsultationsList() {
   const { data, error } = useFetch<TConsultationProps[]>(
-    `pb/reserves?status=false`
+    `reserves?status=false`
   );
 
   const [requestedConsultations, setRequestedConsultations] = useState<

--- a/src/containers/WriteNotification.tsx
+++ b/src/containers/WriteNotification.tsx
@@ -74,7 +74,7 @@ export default function WriteNotification() {
 
   // 새로운 쪽지 전송하기 POST
   const { fetchData } = useFetch<{ message: string }>(
-    'pb/notifications/send',
+    'notifications/send',
     'POST'
   );
 

--- a/src/hooks/sessionContext.tsx
+++ b/src/hooks/sessionContext.tsx
@@ -15,11 +15,13 @@ export const SessionProvider = ({
 }) => {
   const handleLogoutEvent = async () => {
     try {
-      const response = await fetch('pb/logout', {
+      const baseUrl = import.meta.env.VITE_API_KEY;
+      const response = await fetch(`${baseUrl}logout`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
+        credentials: 'include',
       });
 
       if (!response.ok) {
@@ -28,6 +30,7 @@ export const SessionProvider = ({
 
       localStorage.removeItem('loginPB');
       alert('오늘 하루도 고생하셨습니다!😊🎉');
+      window.location.reload();
     } catch (error) {
       console.error(error);
       alert('로그아웃 중 오류가 발생했습니다.');

--- a/src/hooks/sessionContext.tsx
+++ b/src/hooks/sessionContext.tsx
@@ -1,5 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
-import { type TPbDataProps } from '../types/dataTypes';
+import React, { createContext, useContext } from 'react';
 
 type SessionContextType = {
   handleLogoutEvent: () => void;
@@ -14,13 +13,25 @@ export const SessionProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
-  const [_, setPbData] = useState<TPbDataProps | null>(null);
+  const handleLogoutEvent = async () => {
+    try {
+      const response = await fetch('pb/logout', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
 
-  const handleLogoutEvent = () => {
-    setPbData(null);
-    localStorage.removeItem('loginPB');
-    alert('오늘 하루도 고생하셨습니다!😊🎉');
-    window.location.reload();
+      if (!response.ok) {
+        throw new Error('로그아웃에 실패했습니다.');
+      }
+
+      localStorage.removeItem('loginPB');
+      alert('오늘 하루도 고생하셨습니다!😊🎉');
+    } catch (error) {
+      console.error(error);
+      alert('로그아웃 중 오류가 발생했습니다.');
+    }
   };
 
   return (

--- a/src/hooks/useFetch.tsx
+++ b/src/hooks/useFetch.tsx
@@ -41,7 +41,7 @@ export default function useFetch<T>(
       };
 
       // -- (추가) 쿼리 파라미터가 있으면 URL에 추가
-      const fullUrl = appendQueryParams(`${APIKEY}/${url}`, queryParams);
+      const fullUrl = appendQueryParams(`${APIKEY}${url}`, queryParams);
       // --
       const response = await fetch(fullUrl, {
         method,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,13 @@
 import { createRoot } from 'react-dom/client';
-// import { StrictMode } from 'react';
+import { StrictMode } from 'react';
 import App from './App.tsx';
 import { SessionProvider } from './hooks/sessionContext.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
-  // <StrictMode>
-  <SessionProvider>
-    <App />
-  </SessionProvider>
-  // </StrictMode>
+  <StrictMode>
+    <SessionProvider>
+      <App />
+    </SessionProvider>
+  </StrictMode>
 );

--- a/src/pages/ConsultingPage.tsx
+++ b/src/pages/ConsultingPage.tsx
@@ -13,7 +13,7 @@ export default function ConsultingPage() {
   const { customerId } = location.state || {};
 
   const { data, error } = useFetch<TCustomerProps>(
-    `pb/customers/list/${customerId}`
+    `customers/list/${customerId}`
   );
 
   const [customerData, setCustomerData] = useState<TCustomerProps | null>(null);
@@ -49,7 +49,7 @@ export default function ConsultingPage() {
 
           {/* 상담일지 리스트 */}
           <div className='flex-grow overflow-y-auto'>
-            <ConsultationJournalList />
+            <ConsultationJournalList customerId={customerData?.id || 0} />
           </div>
         </div>
 

--- a/src/pages/CustomerDetailPage.tsx
+++ b/src/pages/CustomerDetailPage.tsx
@@ -35,7 +35,7 @@ export default function CustomerDetailPage() {
       </div>
 
       <div className='flex flex-col flex-grow w-1/4 h-full'>
-        <ConsultationJournalList />
+        <ConsultationJournalList customerId={Number(id)} />
       </div>
     </div>
   );

--- a/src/pages/CustomerDetailPage.tsx
+++ b/src/pages/CustomerDetailPage.tsx
@@ -9,7 +9,7 @@ import { type TCustomerProps } from '../types/dataTypes';
 
 export default function CustomerDetailPage() {
   const { id } = useParams();
-  const { data, error } = useFetch<TCustomerProps>(`pb/customers/list/${id}`);
+  const { data, error } = useFetch<TCustomerProps>(`customers/list/${id}`);
   const [customerData, setCustomerData] = useState<TCustomerProps | null>(null);
 
   useEffect(() => {

--- a/src/pages/DictionaryPage.tsx
+++ b/src/pages/DictionaryPage.tsx
@@ -13,7 +13,7 @@ export default function DictionaryPage() {
     TKeywordProps[] | null
   >([]);
 
-  const { data } = useFetch<TKeywordProps[]>('pb/keywords');
+  const { data } = useFetch<TKeywordProps[]>('keywords');
 
   useEffect(() => {
     setKeyWordsListData(data);

--- a/src/pages/NotificationDetailsWindow.tsx
+++ b/src/pages/NotificationDetailsWindow.tsx
@@ -16,7 +16,7 @@ export default function NotificationDetailsWindow({
 
   // 고객 데이터 불러오기
   const { data: customersData, error: customersError } =
-    useFetch<TCustomerProps[]>(`pb/customers/list`);
+    useFetch<TCustomerProps[]>(`customers/list`);
 
   useEffect(() => {
     if (customersData) {

--- a/src/pages/ReadJournalWindow.tsx
+++ b/src/pages/ReadJournalWindow.tsx
@@ -20,7 +20,7 @@ export default function ReadJournalWindow({
   const {
     data: scriptData = { scriptResponseDTOList: [] },
     error: scriptError,
-  } = useFetch<TScriptResponseProps>(`pb/journals/${id}/scripts`);
+  } = useFetch<TScriptResponseProps>(`journals/${id}/scripts`);
   console.error('스크립트 데이터 조회 중 발생한 에러: ', scriptError);
 
   return (

--- a/src/pages/RequestContentPage.tsx
+++ b/src/pages/RequestContentPage.tsx
@@ -10,7 +10,7 @@ export default function RequestContentPage({ id }: { id: string }) {
     const fetchData = async () => {
       try {
         const response = await fetch(
-          `${APIKEY}/pb/journals/reserves/${id}/content`
+          `${APIKEY}journals/reserves/${id}/content`
         );
         const data = await response.text();
         setContent(data);


### PR DESCRIPTION
## #️⃣ 이슈 번호 

> #190 

## 💻 작업 내용

> SessionContext 내에서 로그아웃 api 연결을 통한 세션 삭제 구현

> ConsultationJournalList 한 손님의 상담일지 리스트를 불러오기 위해 useParams으로 받아오던 id의 의미가 페이지에 따라 달라지는 문제 해결

customerDetail 페이지에선 customerId, consulting 페이지에선 consultingId 의미였음
ConsultationJournalList 컴포넌트의 부모 페이지에서 customerId를 전달해주는 것으로 해결

> 검색기능에 대소문자 구분 없도록 toLowerCase로 통일


## 💬 리뷰 요구사항(선택)
